### PR TITLE
Remove extension

### DIFF
--- a/malicious.json
+++ b/malicious.json
@@ -1,5 +1,4 @@
 [
-    "contractshark.solidity-lang",
     "juanbIanco.solidity",
     "Theme.darcula-dark",
     "sigasi.sigasi-visual-hdl",


### PR DESCRIPTION
Reviewed the extension against ClamAV. Found no matches. Internal scan returned no results. Removing this from our malicious extension list.

Closes #1 